### PR TITLE
Adding empty string as a value and making column search param optional

### DIFF
--- a/src/DataTableState.php
+++ b/src/DataTableState.php
@@ -102,7 +102,7 @@ final class DataTableState
     {
         foreach ($parameters->all()['columns'] ?? [] as $key => $search) {
             $column = $this->dataTable->getColumn((int) $key);
-            $value = $this->isInitial ? $search : $search['search']['value'];
+            $value = $this->isInitial ? $search : $search['search']['value'] ?? "";
 
             if ($column->isSearchable() && ('' !== trim($value))) {
                 $this->setColumnSearch($column, $value);


### PR DESCRIPTION
For now in request body when adding a column, "search": {"value": "","regex": false} is required. For cases where search is handled differently this is an unused parameter that is required in a body. It should be optional.
I added fix where this parameter if is not in the body column, default value is empty string